### PR TITLE
Implement --ios option to `new` command

### DIFF
--- a/src/Command/CheckNativePHPUpdatesCommand.php
+++ b/src/Command/CheckNativePHPUpdatesCommand.php
@@ -37,6 +37,16 @@ class CheckNativePHPUpdatesCommand extends Command
 
         $composer = new Composer(new Filesystem(), getcwd());
 
+        if ($composer->packageExistsInComposerFile('nativephp/ios')) {
+            $output->writeln(
+                $returnJson
+                    ? json_encode(['error' => 'This command is not available for NativePHP for iOS yet.'])
+                    : '<error>This command is not available for NativePHP for iOS yet.</error>'
+            );
+
+            return Command::FAILURE;
+        }
+
         try {
             // Throws if composer.json is not found.
             if (!$composer->isComposerFilePresent()) {
@@ -45,7 +55,7 @@ class CheckNativePHPUpdatesCommand extends Command
 
             $output->writeln('Checking for updates to NativePHP...', OutputInterface::VERBOSITY_VERBOSE);
 
-            $currentVersions = $composer->getPackageVersions(['nativephp/electron', 'nativephp/laravel']);
+            $currentVersions = $composer->getPackageVersions(['nativephp/electron', 'nativephp/laravel'], false);
             $latestVersions = NativePHP::getLatestVersions();
             $result = [];
 

--- a/src/Command/NewCommand.php
+++ b/src/Command/NewCommand.php
@@ -55,7 +55,10 @@ class NewCommand extends Command
         $this->output = $output;
         $cwd = getcwd();
         $filePath = $cwd . '/' . $input->getArgument('name');
-        // @phpstan-ignore method.notFound (Relates to getRawTokens only available from ArgvInput.)
+        /**
+         * @noinspection PhpPossiblePolymorphicInvocationInspection
+         * @phpstan-ignore method.notFound (Relates to getRawTokens only available from ArgvInput.)
+         */
         $tokens = $input->getRawTokens(true);
 
         if (($key = array_search('--ios', $tokens)) !== false) {

--- a/src/Command/NewCommand.php
+++ b/src/Command/NewCommand.php
@@ -3,9 +3,10 @@
 namespace NativeCLI\Command;
 
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Composer;
+use NativeCLI\Composer;
 use NativeCLI\Exception\CommandFailed;
 use NativeCLI\NativePHP;
+use NativeCLI\Services\RepositoryManager;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -45,7 +46,8 @@ class NewCommand extends Command
             ->addOption('verification', null, InputOption::VALUE_NONE, 'Indicates whether Jetstream should be scaffolded with email verification support')
             ->addOption('pest', null, InputOption::VALUE_NONE, 'Installs the Pest testing framework')
             ->addOption('phpunit', null, InputOption::VALUE_NONE, 'Installs the PHPUnit testing framework')
-            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists');
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists')
+            ->addOption('ios', null, InputOption::VALUE_NONE, 'Install NativePHP for iOS instead of Desktop');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -53,15 +55,17 @@ class NewCommand extends Command
         $this->output = $output;
         $cwd = getcwd();
         $filePath = $cwd . '/' . $input->getArgument('name');
+        // @phpstan-ignore method.notFound (Relates to getRawTokens only available from ArgvInput.)
+        $tokens = $input->getRawTokens(true);
+
+        if (($key = array_search('--ios', $tokens)) !== false) {
+            unset($tokens[$key]);
+        }
 
         try {
             $output->writeln('Creating a new NativePHP project...');
 
-            /**
-             * @noinspection PhpPossiblePolymorphicInvocationInspection
-             * @phpstan-ignore method.notFound (Relates to getRawTokens only available from ArgvInput.)
-             */
-            $process = new Process(['laravel', 'new', ...$input->getRawTokens(true)]);
+            $process = new Process(['laravel', 'new', ...$tokens]);
             $process->setTty(Process::isTtySupported())
                 ->mustRun(function ($type, $buffer) {
                     $this->output->write($buffer);
@@ -74,11 +78,22 @@ class NewCommand extends Command
             chdir($input->getArgument('name'));
 
             $composer = new Composer(new Filesystem(), $filePath);
-            $composer->requirePackages(
-                NativePHP::getPackagesForComposer(),
-                false,
-                $output
-            );
+
+            if (! $input->getOption('ios')) {
+                $composer->requirePackages(
+                    NativePHP::getPackagesForComposer(),
+                    false,
+                    $output
+                );
+            } else {
+                $repoMan = new RepositoryManager($composer);
+                $repoMan->addRepository('composer', 'https://nativephp-ios.composer.sh');
+                $composer->requirePackages(
+                    ['nativephp/ios'],
+                    false,
+                    $output
+                );
+            }
 
             // Locate PHP & remove new lines
             $php = trim(Process::fromShellCommandline('which php')->mustRun()->getOutput());

--- a/src/Command/UpdateNativePHPCommand.php
+++ b/src/Command/UpdateNativePHPCommand.php
@@ -5,6 +5,7 @@ namespace NativeCLI\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use NativeCLI\Composer;
+use NativeCLI\Exception\CommandFailed;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -110,7 +111,11 @@ class UpdateNativePHPCommand extends Command
 
         $output = new BufferedOutput();
 
-        $this->getApplication()->doRun($checkInput, $output);
+        $status = $this->getApplication()->doRun($checkInput, $output);
+
+        if ($status !== Command::SUCCESS) {
+            throw new CommandFailed($output->fetch());
+        }
 
         return collect(json_decode(trim($output->fetch()), true));
     }

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -46,6 +46,11 @@ class Composer extends \Illuminate\Support\Composer
         return $versions;
     }
 
+    public function getComposerFile(): string
+    {
+        return $this->findComposerFile();
+    }
+
     protected function findComposerLockFile(): string
     {
         $composerLockFile = "$this->workingPath/composer.lock";

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -19,7 +19,7 @@ class Composer extends \Illuminate\Support\Composer
         return true;
     }
 
-    public function getPackageVersions(array $packages): array
+    public function getPackageVersions(array $packages, bool $throwOnError = true): array
     {
         $composerLockFile = $this->findComposerLockFile();
         $composerLockData = json_decode(file_get_contents($composerLockFile), true);
@@ -38,7 +38,7 @@ class Composer extends \Illuminate\Support\Composer
                 }
             }
 
-            if (!$found) {
+            if (!$found && $throwOnError) {
                 throw new RuntimeException("Package [$package] is not installed.");
             }
         }
@@ -60,5 +60,10 @@ class Composer extends \Illuminate\Support\Composer
         }
 
         return $composerLockFile;
+    }
+
+    public function packageExistsInComposerFile(string $package): bool
+    {
+        return $this->hasPackage($package);
     }
 }

--- a/src/NativePHP.php
+++ b/src/NativePHP.php
@@ -8,6 +8,11 @@ class NativePHP
 {
     use PackageVersionRetrieverTrait;
     public const NATIVECLI_RECOMMENDED_VERSION_URL = 'https://nativecli.com/resources/latestRecommendedVersion.json';
+    public const NATIVEPHP_PACKAGES = [
+        'nativephp/electron',
+        'nativephp/laravel',
+        'nativephp/ios',
+    ];
 
     /**
      * @throws Exception
@@ -48,7 +53,7 @@ class NativePHP
     {
         return [
             'nativephp/electron' => self::getVersionForPackage('nativephp/electron'),
-            'nativephp/laravel' => self::getVersionForPackage('nativephp/laravel')
+            'nativephp/laravel' => self::getVersionForPackage('nativephp/laravel'),
         ];
     }
 }

--- a/src/Services/RepositoryManager.php
+++ b/src/Services/RepositoryManager.php
@@ -2,9 +2,10 @@
 
 namespace NativeCLI\Services;
 
+use JsonException;
 use NativeCLI\Composer;
 
-class RepositoryManager
+readonly class RepositoryManager
 {
     public function __construct(
         private Composer $composer
@@ -12,7 +13,7 @@ class RepositoryManager
     }
 
     /**
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function addRepository(string $type, string $url): bool
     {
@@ -35,7 +36,7 @@ class RepositoryManager
     }
 
     /**
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function repositoryExists(string $type, string $url): bool
     {

--- a/src/Services/RepositoryManager.php
+++ b/src/Services/RepositoryManager.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace NativeCLI\Services;
+
+use NativeCLI\Composer;
+
+class RepositoryManager
+{
+    public function __construct(
+        private Composer $composer
+    ) {}
+
+    /**
+     * @throws \JsonException
+     */
+    public function addRepository(string $type, string $url): bool
+    {
+        if ($this->repositoryExists($type, $url)) {
+            return true;
+        }
+
+        $this->composer->modify(
+            function (array $composerFile) use ($type, $url) {
+                $composerFile['repositories'][] = [
+                    'type' => $type,
+                    'url' => $url
+                ];
+
+                return $composerFile;
+            }
+        );
+
+        return $this->repositoryExists($type, $url);
+    }
+
+    /**
+     * @throws \JsonException
+     */
+    public function repositoryExists(string $type, string $url): bool
+    {
+        $composerFile = json_decode(
+            file_get_contents(
+                $this->composer->getComposerFile()
+            ),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        $repositories = $composerFile['repositories'] ?? [];
+
+        foreach ($repositories as $repository) {
+            if ($repository['type'] === $type && $repository['url'] === $url) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Version.php
+++ b/src/Version.php
@@ -10,7 +10,7 @@ class Version
 {
     use PackageVersionRetrieverTrait;
 
-    public const VERSION = '1.0.0-release.1';
+    public const VERSION = '1.0.1-release.1';
 
     public static function get(): ?SemanticVersion
     {


### PR DESCRIPTION
With the Early Access for iOS now being available for license holders, it makes sense for the `new` command to be able to bootstrap the `nativephp/ios` package instead of the desktop packages.

This update allows you to specify `--ios` like so:

```
nativecli new MyNewApp --ios
```

This will configure the custom repository and allow Composer to prompt for access credentials during install as normal.

**NOTE:** The check-update and update commands do not currently support the new nativephp/ios repository. A separate card needs to be opened to find a path forward for this.