### PR TITLE
Support for new mobile repo

### DIFF
--- a/src/Command/NewCommand.php
+++ b/src/Command/NewCommand.php
@@ -44,7 +44,7 @@ class NewCommand extends Command
             ->addOption('npm', null, InputOption::VALUE_NONE, 'Install and build NPM dependencies')
             ->addOption('using', null, InputOption::VALUE_OPTIONAL, 'Install a custom starter kit from a community maintained package')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces install even if the directory already exists')
-            ->addOption('ios', null, InputOption::VALUE_NONE, 'Install NativePHP for iOS instead of Desktop');
+            ->addOption('mobile', null, InputOption::VALUE_NONE, 'Install NativePHP for Mobile instead of Desktop');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -58,7 +58,7 @@ class NewCommand extends Command
          */
         $tokens = $input->getRawTokens(true);
 
-        if (($key = array_search('--ios', $tokens)) !== false) {
+        if (($key = array_search('--mobile', $tokens)) !== false) {
             unset($tokens[$key]);
         }
 
@@ -79,7 +79,7 @@ class NewCommand extends Command
 
             $composer = new Composer(new Filesystem(), $filePath);
 
-            if (!$input->getOption('ios')) {
+            if (!$input->getOption('mobile')) {
                 $composer->requirePackages(
                     packages: ['nativephp/electron'],
                     output: $output,
@@ -87,9 +87,9 @@ class NewCommand extends Command
                 );
             } else {
                 $repoMan = new RepositoryManager($composer);
-                $repoMan->addRepository('composer', 'https://nativephp-ios.composer.sh');
+                $repoMan->addRepository('composer', 'https://nativephp.composer.sh');
                 $composer->requirePackages(
-                    packages: ['nativephp/ios'],
+                    packages: ['nativephp/mobile'],
                     output: $output,
                     tty: Process::isTtySupported()
                 );


### PR DESCRIPTION
This pull request updates the `NewCommand` class to generalize support for mobile platforms instead of specifically targeting iOS. The changes include renaming options, updating logic, and modifying repository URLs and package names accordingly.

### Updates for mobile platform support:

* [`src/Command/NewCommand.php`](diffhunk://#diff-11c28d0b5c56b11d336396b3836aa6404dc60cc4812f7a60bd300726b5c1b139L47-R47): Replaced the `--ios` option with `--mobile` in the `configure()` method to reflect the broader mobile platform support.
* [`src/Command/NewCommand.php`](diffhunk://#diff-11c28d0b5c56b11d336396b3836aa6404dc60cc4812f7a60bd300726b5c1b139L61-R61): Updated the logic in `execute()` to check for the `--mobile` option instead of `--ios`. [[1]](diffhunk://#diff-11c28d0b5c56b11d336396b3836aa6404dc60cc4812f7a60bd300726b5c1b139L61-R61) [[2]](diffhunk://#diff-11c28d0b5c56b11d336396b3836aa6404dc60cc4812f7a60bd300726b5c1b139L82-R92)
* [`src/Command/NewCommand.php`](diffhunk://#diff-11c28d0b5c56b11d336396b3836aa6404dc60cc4812f7a60bd300726b5c1b139L82-R92): Changed the repository URL from `https://nativephp-ios.composer.sh` to `https://nativephp.composer.sh` and updated the package name from `nativephp/ios` to `nativephp/mobile` for mobile-specific installations.