### PR TITLE
Update ios:install to mobile:install

### DIFF
--- a/src/Command/InstallNativePHPMobileCommand.php
+++ b/src/Command/InstallNativePHPMobileCommand.php
@@ -13,8 +13,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 #[AsCommand(
-    name: 'ios:install',
-    description: 'Install the NativePHP Mobile CLI tool'
+    name: 'mobile:install',
+    description: 'Install the NativePHP for Mobile in an existing Laravel application.'
 )]
 class InstallNativePHPMobileCommand extends Command
 {
@@ -27,9 +27,9 @@ class InstallNativePHPMobileCommand extends Command
 
         $composer = new Composer(new Filesystem(), getcwd());
         $repoMan = new RepositoryManager($composer);
-        $repoMan->addRepository('composer', 'https://nativephp-ios.composer.sh');
+        $repoMan->addRepository('composer', 'https://nativephp.composer.sh');
         $composerInstallSuccessful = $composer->requirePackages(
-            packages: ['nativephp/ios'],
+            packages: ['nativephp/mobile'],
             output: $output,
             tty: Process::isTtySupported()
         );
@@ -42,7 +42,7 @@ class InstallNativePHPMobileCommand extends Command
 
         $php = trim(Process::fromShellCommandline('which php')->mustRun()->getOutput());
 
-        $output->writeln('Installing NativePHP for iOS');
+        $output->writeln('Installing NativePHP for Mobile...');
 
         $nativePhpInstall = new Process([$php, 'artisan', 'native:install', '--no-interaction']);
         $nativePhpInstall->setTty(Process::isTtySupported())


### PR DESCRIPTION
This pull request updates the `InstallNativePHPMobileCommand` to generalize the installation process for NativePHP on mobile platforms, replacing iOS-specific references with mobile-specific ones. The changes include renaming the command, updating repository URLs, package names, and user-facing messages.

### Command and description updates:
* Renamed the command from `ios:install` to `mobile:install` and updated its description to reflect the broader scope of installing NativePHP for mobile in a Laravel application. (`src/Command/InstallNativePHPMobileCommand.php`, [src/Command/InstallNativePHPMobileCommand.phpL16-R17](diffhunk://#diff-322b4c5a1d0055120e81ac6a4afd3971e793411975d739cca9502a2b2aff5101L16-R17))

### Repository and package updates:
* Changed the repository URL from `https://nativephp-ios.composer.sh` to `https://nativephp.composer.sh`. (`src/Command/InstallNativePHPMobileCommand.php`, [src/Command/InstallNativePHPMobileCommand.phpL30-R32](diffhunk://#diff-322b4c5a1d0055120e81ac6a4afd3971e793411975d739cca9502a2b2aff5101L30-R32))
* Updated the package name from `nativephp/ios` to `nativephp/mobile` to align with the new mobile-focused approach. (`src/Command/InstallNativePHPMobileCommand.php`, [src/Command/InstallNativePHPMobileCommand.phpL30-R32](diffhunk://#diff-322b4c5a1d0055120e81ac6a4afd3971e793411975d739cca9502a2b2aff5101L30-R32))

### User-facing message updates:
* Updated the installation message from "Installing NativePHP for iOS" to "Installing NativePHP for Mobile..." to provide clearer feedback to the user. (`src/Command/InstallNativePHPMobileCommand.php`, [src/Command/InstallNativePHPMobileCommand.phpL45-R45](diffhunk://#diff-322b4c5a1d0055120e81ac6a4afd3971e793411975d739cca9502a2b2aff5101L45-R45))